### PR TITLE
Prefer glue_data() when data might be list-ish, not an actual environment

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -223,8 +223,7 @@ odin_file <- function(...) {
 
 
 glue_whisker <- function(template, data) {
-  glue::glue(template, .envir = data, .open = "{{", .close = "}}",
-             .trim = FALSE)
+  glue::glue_data(data, template, .open = "{{", .close = "}}", .trim = FALSE)
 }
 
 


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. I'm going to temporarily back off on the associated change in glue, just so I can release without any breakage of other packages.

But please do consider this a heads up that, in the future, `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I'd like to make that actually true.

OTOH `glue_data()` *does* officially accept something "list-ish" as `.x`. So I think it's a better choice for your usage.

Backstory in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764